### PR TITLE
Add a new client with no direct communication between HERD and Clover client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(concurrentqueue REQUIRED) # cameron314/concurrentqueue
 find_package(Folly REQUIRED)
 find_package(Threads REQUIRED)
 find_package(Boost REQUIRED COMPONENTS coroutine system thread)
+find_package(fmt REQUIRED)
 
 add_subdirectory(src)
 add_subdirectory(exp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,3 +11,4 @@ add_subdirectory(clover_wrapper)
 add_subdirectory(util)
 
 add_subdirectory(combined)
+add_subdirectory(separated)

--- a/src/combined/CMakeLists.txt
+++ b/src/combined/CMakeLists.txt
@@ -1,6 +1,3 @@
-# cameron314/concurrentqueue
-find_package(concurrentqueue)
-
 set(COMBINED_COMMON_LIB
   gflags
   glog

--- a/src/combined/README.md
+++ b/src/combined/README.md
@@ -9,16 +9,16 @@
 Change the following items:
 
 - `herd_workers` in [`scripts/combined/launch_server.sh`](../../scripts/combined/launch_server.sh#L22)
-- `NUM_WORKERS` and `NUM_CLIENTS` in [`src/herd/main.h`](../herd/main.h#L33) and [`src/combined/herd_main.h`](herd_main.h#L38)
+- `NUM_WORKERS` and `NUM_CLIENTS` in [`src/herd/main.h`](../herd/main.h#L33) and [`src/combined/herd_main.h`](herd_main.h#L40)
 - `--herd_threads X` in [`scripts/combined/launch_client.sh`](../../scripts/combined/launch_client.sh#L32), where `X` is the number of HERD threads at that client process.
 
 #### Value size
 
 Change the following items:
 
-- `HERD_VALUE_SIZE` in [`src/herd/main.h`](../herd/main.h#L23) and [`src/combined/herd_main.h`](herd_main.h#L25).
+- `HERD_VALUE_SIZE` in [`src/herd/main.h`](../herd/main.h#L23) and [`src/combined/herd_main.h`](herd_main.h#L27).
 - Increase `MICA_OBJ_SIZE` in [`src/mica/mica.h`](../mica/mica.h#L28) if needed. See `MICA_MAX_VALUE` in the same file for the maximum supported value size under different settings.
-- Decrease `HERD_NUM_KEYS` in [`src/herd/main.h`](../herd/main.h#L22) and [`src/combined/herd_main.h`](herd_main.h#L24) if needed.
+- Decrease `HERD_NUM_KEYS` in [`src/herd/main.h`](../herd/main.h#L22) and [`src/combined/herd_main.h`](herd_main.h#L26) if needed.
   - For example, when `MICA_OBJ_SIZE` is 1024, we may change this value to `262144`.
-- Increase `RR_SIZE` in [`src/herd/main.h`](../herd/main.h#L46) and [`src/combined/herd_main.h`](herd_main.h#L53) if needed. Note that changing this value might need more hugepages.
+- Increase `RR_SIZE` in [`src/herd/main.h`](../herd/main.h#L46) and [`src/combined/herd_main.h`](herd_main.h#L55) if needed. Note that changing this value might need more hugepages.
   - For example, using 24 HERD workers at server, 72 HERD client threads and `MICA_OBJ_SIZE` being 1024, we may change this value to `128 << 20` and use 65536 2MB huge pages.

--- a/src/combined/herd_main.h
+++ b/src/combined/herd_main.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdint>
 
 #include "clover/mitsume_struct.h"
@@ -94,6 +96,20 @@ enum HerdResponseCode : unsigned int { kNormal = 0, kOffloaded = 1 };
  */
 inline mitsume_key ConvertHerdKeyToCloverKey(mica_key *herd_key, uint8_t tid) {
   mitsume_key clover_key = reinterpret_cast<uint64 *>(herd_key)[1];
+  clover_key &= ~((1UL << 8) - 1UL);  // mask out lowest 8 bits
+  return (clover_key | tid);
+}
+
+/**
+ * @brief Converts HERD key hash of specific worker thread to the key used in
+ * Clover by replacing the lowest 8 bits with the worker thread id.
+ *
+ * @param key the key used in HERD
+ * @param tid the id of HERD worker thread
+ * @return the corresponding key to query in Clover
+ */
+inline mitsume_key ConvertHerdKeyToCloverKey(const uint128 key, uint8_t tid) {
+  mitsume_key clover_key = key.second;
   clover_key &= ~((1UL << 8) - 1UL);  // mask out lowest 8 bits
   return (clover_key | tid);
 }

--- a/src/herd/worker.c
+++ b/src/herd/worker.c
@@ -205,7 +205,7 @@ void* run_worker(void* arg) {
       wr[wr_i].opcode = IBV_WR_SEND_WITH_IMM;
       wr[wr_i].num_sge = 1;
       wr[wr_i].sg_list = &sgl[wr_i];
-      wr[wr_i].imm_data = wrkr_lid;
+      wr[wr_i].imm_data = op_ptr_arr[wr_i]->seq;
 
       wr[wr_i].send_flags =
           ((nb_tx[cb_i][ud_qp_i] & UNSIG_BATCH_) == 0) ? IBV_SEND_SIGNALED : 0;

--- a/src/herd/worker.c
+++ b/src/herd/worker.c
@@ -1,6 +1,12 @@
+#define _DEFAULT_SOURCE
+#include <sys/shm.h>
+
 #include "hrd.h"
 #include "main.h"
 #include "mica.h"
+
+#define INLINE_CUTOFF \
+  (HRD_MAX_INLINE - (sizeof(struct mica_key) + MICA_OBJ_METADATA_SIZE))
 
 void* run_worker(void* arg) {
   int i, ret;
@@ -47,6 +53,19 @@ void* run_worker(void* arg) {
   assert(sid != -1);
   req_buf = shmat(sid, 0, 0);
   assert(req_buf != (void*)-1);
+
+  struct ibv_mr** mica_log_mrs = NULL;
+  if (HERD_VALUE_SIZE > INLINE_CUTOFF) {
+    mica_log_mrs = malloc(sizeof(struct ibv_mr*) * num_server_ports);
+    for (i = 0; i < num_server_ports; i++) {
+      mica_log_mrs[i] = ibv_reg_mr(cb[i]->pd, kv.ht_log, HERD_LOG_CAP, 0);
+      if (mica_log_mrs[i] == NULL) {
+        fputs("ibv_reg_mr returns NULL\n", stderr);
+        exit(EXIT_FAILURE);
+      }
+    }
+    printf("MICA log registered to PD, size=%u\n", HERD_LOG_CAP);
+  }
 
   /* Create an address handle for each client */
   struct ibv_ah* ah[NUM_CLIENTS];
@@ -212,7 +231,11 @@ void* run_worker(void* arg) {
       if ((nb_tx[cb_i][ud_qp_i] & UNSIG_BATCH_) == UNSIG_BATCH_) {
         hrd_poll_cq(cb[cb_i]->dgram_send_cq[ud_qp_i], 1, &wc);
       }
-      wr[wr_i].send_flags |= IBV_SEND_INLINE;
+      if (HERD_VALUE_SIZE <= INLINE_CUTOFF) {
+        wr[wr_i].send_flags |= IBV_SEND_INLINE;
+      } else {
+        sgl[wr_i].lkey = mica_log_mrs[ud_qp_i]->lkey;
+      }
 
       HRD_MOD_ADD(ws[clt_i], WINDOW_SIZE);
 

--- a/src/separated/CMakeLists.txt
+++ b/src/separated/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(COMBINED_HDRS ../combined/herd_main.h)
+
+add_executable(client_primary_lat primary_lat.cc ${COMBINED_HDRS})
+target_link_libraries(client_primary_lat Folly::folly gflags glog mica libhrd zipfian concurrentqueue::concurrentqueue)
+
+install(TARGETS client_primary_lat)

--- a/src/separated/CMakeLists.txt
+++ b/src/separated/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(COMBINED_HDRS ../combined/herd_main.h)
 
+set(COMMON_SRCS timing.h)
+
 add_library(separated_herd_client
   herd_client.h
   herd_client.cc
@@ -12,7 +14,7 @@ target_link_libraries(separated_herd_client
   concurrentqueue::concurrentqueue
 )
 
-add_executable(client_primary_lat primary_lat.cc)
+add_executable(client_primary_lat primary_lat.cc ${COMMON_SRCS})
 target_link_libraries(client_primary_lat
   Folly::folly
   fmt::fmt

--- a/src/separated/CMakeLists.txt
+++ b/src/separated/CMakeLists.txt
@@ -1,6 +1,25 @@
 set(COMBINED_HDRS ../combined/herd_main.h)
 
-add_executable(client_primary_lat primary_lat.cc ${COMBINED_HDRS})
-target_link_libraries(client_primary_lat Folly::folly gflags glog mica libhrd zipfian concurrentqueue::concurrentqueue)
+add_library(separated_herd_client
+  herd_client.h
+  herd_client.cc
+  ${COMBINED_HDRS}
+)
+target_link_libraries(separated_herd_client
+  Folly::folly
+  mica
+  libhrd
+  concurrentqueue::concurrentqueue
+)
+
+add_executable(client_primary_lat primary_lat.cc)
+target_link_libraries(client_primary_lat
+  Folly::folly
+  fmt::fmt
+  gflags
+  glog
+  separated_herd_client
+  zipfian
+)
 
 install(TARGETS client_primary_lat)

--- a/src/separated/CMakeLists.txt
+++ b/src/separated/CMakeLists.txt
@@ -24,4 +24,17 @@ target_link_libraries(client_primary_lat
   zipfian
 )
 
-install(TARGETS client_primary_lat)
+add_executable(separated_client tput_client.cc ${COMMON_SRCS})
+target_link_libraries(separated_client
+  Boost::thread
+  Folly::folly
+  fmt::fmt
+  gflags
+  glog
+  mitsume
+  clover_wrapper
+  separated_herd_client
+  zipfian
+)
+
+install(TARGETS client_primary_lat separated_client)

--- a/src/separated/CMakeLists.txt
+++ b/src/separated/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(separated_client
   fmt::fmt
   gflags
   glog
+  affinity
   mitsume
   clover_wrapper
   separated_herd_client

--- a/src/separated/herd_client.cc
+++ b/src/separated/herd_client.cc
@@ -109,6 +109,11 @@ void HerdClient::PostRecvWrs(const std::vector<unsigned int>& wr_id_list) {
 }
 
 bool HerdClient::PostRequest(uint128 mica_key, const char* value,
+                             unsigned int len, bool update) {
+  return PostRequest(mica_key, value, len, update, PickRemoteWorker(mica_key));
+}
+
+bool HerdClient::PostRequest(uint128 mica_key, const char* value,
                              unsigned int len, bool update,
                              unsigned int rem_worker) {
   if (pending_req_ == WINDOW_SIZE) {

--- a/src/separated/herd_client.cc
+++ b/src/separated/herd_client.cc
@@ -152,7 +152,7 @@ bool HerdClient::PostRequest(uint128 mica_key, const char* value,
   wr.wr.rdma.rkey = master_qp_->rkey;
 
   int ret = ibv_post_send(cb_->conn_qp[0], &wr, &bad_wr);
-  XCHECK_EQ(ret, 0) << strerror(ret);
+  XLOGF_IF(FATAL, ret != 0, "ibv_post_send: {}", strerror(ret));
 
   pending_req_++;
   HRD_MOD_ADD(req_buf_idx_, req_buf_entries_);

--- a/src/separated/herd_client.cc
+++ b/src/separated/herd_client.cc
@@ -1,0 +1,198 @@
+#include "herd_client.h"
+
+#include <fmt/core.h>
+#include <folly/logging/xlog.h>
+
+#include <cstdlib>
+#include <numeric>
+
+HerdResp::HerdResp(uint128 key, unsigned int rem, bool update)
+    : key_(key), buf_(nullptr), rem_(rem), offloaded_(false), update_(update) {}
+
+uint128 HerdResp::Key() const { return key_; }
+
+mitsume_key HerdResp::CloverKey() const {
+  return ConvertHerdKeyToCloverKey(key_, rem_);
+}
+
+const volatile uint8_t* HerdResp::ValuePtr() const { return buf_; }
+
+bool HerdResp::Offloaded() const { return offloaded_; }
+
+HerdClient::HerdClient(int gcid, int server_ports, int client_ports,
+                       int base_port_index)
+    : gcid_(gcid),
+      num_server_ports_(server_ports),
+      num_client_ports_(client_ports),
+      req_buf_entries_(HERD_VALUE_SIZE > kInlineCutOff ? WINDOW_SIZE : 1U),
+      req_buf_idx_(0),
+      pending_req_(0),
+      pending_unsig_(0),
+      window_slots_(NUM_WORKERS, 0) {
+  int port_index = base_port_index + gcid_ % num_client_ports_;
+  int dgram_buf_size = std::max(kDgramEntrySize * WINDOW_SIZE, 4096);
+
+  cb_ = hrd_ctrl_blk_init(gcid_,           // local hid
+                          port_index,      // client ib port index
+                          -1,              // numa node id
+                          1,               // # of conn qps
+                          1,               // is UC
+                          nullptr,         // preallocated conn buf
+                          4096,            // conn buf size
+                          -1,              // conn buf shm key
+                          1,               // # of dgram qps
+                          dgram_buf_size,  // dgram buf size
+                          -1               // dgram buf shm key
+  );
+
+  req_buf_ =
+      static_cast<mica_op*>(memalign(4096, sizeof(mica_op) * req_buf_entries_));
+  XCHECK_NE(req_buf_, nullptr);
+  req_mr_ =
+      ibv_reg_mr(cb_->pd, req_buf_, sizeof(mica_op) * req_buf_entries_, 0);
+  XCHECK_NE(req_mr_, nullptr);
+
+  for (int i = 0; i < WINDOW_SIZE; i++) {
+    recv_sges_[i].length = kDgramEntrySize;
+    recv_sges_[i].lkey = cb_->dgram_buf_mr->lkey;
+
+    recv_wrs_[i].num_sge = 1;
+  }
+
+  std::vector<unsigned int> recv_wr_ids(WINDOW_SIZE);
+  std::iota(recv_wr_ids.begin(), recv_wr_ids.end(), 0);
+  PostRecvWrs(recv_wr_ids);
+}
+
+void HerdClient::ConnectToServer() {
+  auto conn_qp_name = fmt::format("client-conn-{}", gcid_);
+  auto dgram_qp_name = fmt::format("client-dgram-{}", gcid_);
+  hrd_publish_conn_qp(cb_, 0, conn_qp_name.c_str());
+  hrd_publish_dgram_qp(cb_, 0, dgram_qp_name.c_str());
+  XLOGF(INFO, "Client {} published conn and dgram QPs.", gcid_);
+
+  int server_port_index = gcid_ % num_server_ports_;
+  auto master_qp_name = fmt::format("master-{}-{}", server_port_index, gcid_);
+  master_qp_ = nullptr;
+  while (master_qp_ == nullptr) {
+    master_qp_ = hrd_get_published_qp(master_qp_name.c_str());
+    if (master_qp_ == nullptr) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+  }
+  XLOGF(INFO, "Client {} found master.", gcid_);
+
+  hrd_connect_qp(cb_, 0, master_qp_);
+  XLOGF(INFO, "Client {} connected to master.", gcid_);
+
+  hrd_wait_till_ready(master_qp_name.c_str());
+}
+
+void HerdClient::PostRecvWrs(const std::vector<unsigned int>& wr_id_list) {
+  XCHECK_LE(static_cast<int>(wr_id_list.size()), WINDOW_SIZE);
+
+  for (unsigned int i = 0; i < wr_id_list.size(); i++) {
+    auto wr_id = wr_id_list[i];
+    recv_sges_[i].addr =
+        reinterpret_cast<uint64_t>(cb_->dgram_buf + wr_id * kDgramEntrySize);
+
+    recv_wrs_[i].wr_id = wr_id;
+    recv_wrs_[i].next = &recv_wrs_[i + 1];
+    recv_wrs_[i].sg_list = &recv_sges_[i];
+  }
+  recv_wrs_[wr_id_list.size() - 1].next = nullptr;
+
+  ibv_recv_wr* bad;
+  int rc = ibv_post_recv(cb_->dgram_qp[0], recv_wrs_, &bad);
+  XLOGF_IF(FATAL, rc != 0, "ibv_post_recv: {} (wr_id={})", strerror(rc),
+           bad->wr_id);
+}
+
+bool HerdClient::PostRequest(uint128 mica_key, const char* value,
+                             unsigned int len, bool update,
+                             unsigned int rem_worker) {
+  if (pending_req_ == WINDOW_SIZE) {
+    // must call GetResponses now
+    return false;
+  }
+
+  if (pending_unsig_ == UNSIG_BATCH_) {
+    ibv_wc wc;
+    hrd_poll_cq(cb_->conn_cq[0], 1, &wc);
+  }
+
+  mica_op* buf = &req_buf_[req_buf_idx_];
+  *(uint128*)buf = mica_key;
+  buf->opcode = update ? HERD_OP_PUT : HERD_OP_GET;
+  buf->seq = pending_req_;
+  buf->val_len = len;
+  if (update && value != nullptr) {
+    XCHECK_LE(len, sizeof(mica_op::value));
+    std::memcpy(buf->value, value, len);
+  }
+
+  ibv_sge sge;
+  sge.length = update ? HERD_PUT_REQ_SIZE : HERD_GET_REQ_SIZE;
+  sge.addr = reinterpret_cast<uint64_t>(buf);
+  sge.lkey = req_mr_->lkey;
+
+  ibv_send_wr wr, *bad_wr;
+  wr.opcode = IBV_WR_RDMA_WRITE;
+  wr.sg_list = &sge;
+  wr.num_sge = 1;
+  wr.next = nullptr;
+  wr.send_flags = pending_unsig_ == 0 ? IBV_SEND_SIGNALED : 0;
+  if (HERD_VALUE_SIZE <= kInlineCutOff || !update) {
+    wr.send_flags |= IBV_SEND_INLINE;
+  }
+
+  wr.wr.rdma.remote_addr =
+      master_qp_->buf_addr +
+      Offset(rem_worker, gcid_, window_slots_[rem_worker]) * sizeof(mica_op);
+  wr.wr.rdma.rkey = master_qp_->rkey;
+
+  int ret = ibv_post_send(cb_->conn_qp[0], &wr, &bad_wr);
+  XCHECK_EQ(ret, 0) << strerror(ret);
+
+  pending_req_++;
+  HRD_MOD_ADD(req_buf_idx_, req_buf_entries_);
+  HRD_MOD_ADD(pending_unsig_, UNSIG_BATCH);
+  HRD_MOD_ADD(window_slots_[rem_worker], WINDOW_SIZE);
+  resps_.emplace_back(mica_key, rem_worker, update);
+
+  return true;
+}
+
+void HerdClient::GetResponses(std::vector<HerdResp>& resps) {
+  if (pending_req_ == 0) {
+    return;
+  }
+
+  ibv_wc wc[WINDOW_SIZE];
+  hrd_poll_cq(cb_->dgram_recv_cq[0], pending_req_, wc);
+
+  std::vector<unsigned int> recv_wr_ids(pending_req_);
+
+  for (unsigned int i = 0; i < pending_req_; i++) {
+    recv_wr_ids[i] = wc[i].wr_id;
+    // request sequence number
+    uint8_t seq = wc[i].imm_data & 0xffU;
+    unsigned int resp_code = wc[i].imm_data >> 8;
+    XCHECK(resp_code == HerdResponseCode::kNormal ||
+           resp_code == HerdResponseCode::kOffloaded);
+
+    auto& resp = resps_.at(seq);
+    if (resp_code == HerdResponseCode::kOffloaded) {
+      resp.offloaded_ = true;
+    }
+    if (!resp.update_) {
+      resps_.at(seq).buf_ =
+          cb_->dgram_buf + wc[i].wr_id * kDgramEntrySize + sizeof(ibv_grh);
+    }
+  }
+
+  PostRecvWrs(recv_wr_ids);
+  pending_req_ = 0;
+  resps.swap(resps_);
+  resps_.clear();
+}

--- a/src/separated/herd_client.h
+++ b/src/separated/herd_client.h
@@ -9,6 +9,8 @@ class HerdClient {
   HerdClient(int gcid, int server_ports, int client_ports, int base_port_index);
   void ConnectToServer();
   bool PostRequest(uint128 mica_key, const char* value, unsigned int len,
+                   bool update);
+  bool PostRequest(uint128 mica_key, const char* value, unsigned int len,
                    bool update, unsigned int rem_worker);
   void GetResponses(std::vector<HerdResp>& resps);
 
@@ -41,6 +43,9 @@ class HerdClient {
   ibv_sge recv_sges_[WINDOW_SIZE];
 
   void PostRecvWrs(const std::vector<unsigned int>& wr_id_list);
+  inline unsigned int PickRemoteWorker(const uint128 k) {
+    return k.second % NUM_WORKERS;
+  }
 };
 
 class HerdResp {

--- a/src/separated/herd_client.h
+++ b/src/separated/herd_client.h
@@ -6,6 +6,9 @@ class HerdResp;
 
 class HerdClient {
  public:
+  static inline unsigned int PickRemoteWorker(const uint128 k) {
+    return k.second % NUM_WORKERS;
+  }
   HerdClient(int gcid, int server_ports, int client_ports, int base_port_index);
   void ConnectToServer();
   bool PostRequest(uint128 mica_key, const char* value, unsigned int len,
@@ -43,9 +46,6 @@ class HerdClient {
   ibv_sge recv_sges_[WINDOW_SIZE];
 
   void PostRecvWrs(const std::vector<unsigned int>& wr_id_list);
-  inline unsigned int PickRemoteWorker(const uint128 k) {
-    return k.second % NUM_WORKERS;
-  }
 };
 
 class HerdResp {

--- a/src/separated/herd_client.h
+++ b/src/separated/herd_client.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "combined/herd_main.h"
+
+class HerdResp;
+
+class HerdClient {
+ public:
+  HerdClient(int gcid, int server_ports, int client_ports, int base_port_index);
+  void ConnectToServer();
+  bool PostRequest(uint128 mica_key, const char* value, unsigned int len,
+                   bool update, unsigned int rem_worker);
+  void GetResponses(std::vector<HerdResp>& resps);
+
+ private:
+  static constexpr int kDgramEntrySize =
+      sizeof(ibv_grh) +
+      std::max(HERD_VALUE_SIZE, static_cast<int>(sizeof(mitsume_key)));
+
+  // this thread's global client id
+  const int gcid_;
+  const int num_server_ports_;
+  const int num_client_ports_;
+
+  hrd_ctrl_blk* cb_;
+  hrd_qp_attr* master_qp_;
+
+  mica_op* req_buf_;
+  ibv_mr* req_mr_;
+  const unsigned int req_buf_entries_;
+  unsigned int req_buf_idx_;
+  unsigned int pending_req_;
+  unsigned int pending_unsig_;
+
+  std::vector<HerdResp> resps_;
+
+  std::vector<int> window_slots_;
+
+  // work requests for responses
+  ibv_recv_wr recv_wrs_[WINDOW_SIZE];
+  ibv_sge recv_sges_[WINDOW_SIZE];
+
+  void PostRecvWrs(const std::vector<unsigned int>& wr_id_list);
+};
+
+class HerdResp {
+  friend bool HerdClient::PostRequest(uint128 mica_key, const char* value,
+                                      unsigned int len, bool update,
+                                      unsigned int rem_worker);
+  friend void HerdClient::GetResponses(std::vector<HerdResp>& resps);
+
+ public:
+  HerdResp(uint128 key, unsigned int rem, bool update);
+  uint128 Key() const;
+  mitsume_key CloverKey() const;
+  const volatile uint8_t* ValuePtr() const;
+  bool Offloaded() const;
+
+ private:
+  uint128 key_;
+  const volatile uint8_t* buf_;
+  const unsigned int rem_;
+  bool offloaded_;
+  bool update_;
+};

--- a/src/separated/primary_lat.cc
+++ b/src/separated/primary_lat.cc
@@ -13,7 +13,7 @@ DEFINE_int32(base_port_index, 0, "Base IB port index");
 
 std::vector<uint128> GenerateTrace() {
   constexpr size_t kTraceLength = 2'000'000;
-  ZipfianGenerator gen(8 << 20, 0.99);
+  ZipfianGenerator gen(HERD_NUM_KEYS, 0.99);
   std::vector<uint128> trace;
 
   for (size_t i = 0; i < kTraceLength; i++) {

--- a/src/separated/primary_lat.cc
+++ b/src/separated/primary_lat.cc
@@ -1,10 +1,30 @@
-#include "combined/herd_main.h"
+#include <folly/logging/xlog.h>
+#include <gflags/gflags.h>
 
-int main(int argc, char **argv) {
-  FLAGS_colorlogtostderr = true;
-  FLAGS_alsologtostderr = true;
+#include "herd_client.h"
+
+DEFINE_int32(server_ports, 1, "Number of server IB ports");
+DEFINE_int32(client_ports, 1, "Number of client IB ports");
+DEFINE_int32(base_port_index, 0, "Base IB port index");
+
+int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
+
+  // check at runtime (instead of compile-time) to allow other codes to compile
+  XCHECK_EQ(NUM_CLIENTS, 1);
+
+  {
+    auto memcached_ip = std::getenv("HRD_REGISTRY_IP");
+    XCHECK_NE(memcached_ip, nullptr);
+    XLOGF(INFO, "Memcached server: {}", memcached_ip);
+  }
+  XLOGF(INFO, "Value size: {}", HERD_VALUE_SIZE);
+
+  HerdClient cli(0, FLAGS_server_ports, FLAGS_client_ports,
+                 FLAGS_base_port_index);
+  cli.ConnectToServer();
+
   return 0;
 }

--- a/src/separated/primary_lat.cc
+++ b/src/separated/primary_lat.cc
@@ -1,35 +1,15 @@
 #include <folly/logging/xlog.h>
 #include <gflags/gflags.h>
-#include <x86intrin.h>
 
-#include <chrono>
-#include <thread>
 #include <vector>
 
 #include "herd_client.h"
+#include "timing.h"
 #include "util/zipfian_generator.h"
 
 DEFINE_int32(server_ports, 1, "Number of server IB ports");
 DEFINE_int32(client_ports, 1, "Number of client IB ports");
 DEFINE_int32(base_port_index, 0, "Base IB port index");
-
-unsigned long Rdtscp() {
-  unsigned int foo;
-  return __rdtscp(&foo);
-}
-
-// Returns cycles per microseconds
-unsigned long MeasureClockFreq() {
-  static unsigned long freq = 0;
-  if (freq > 0) {
-    return freq;
-  }
-  auto a = Rdtscp();
-  std::this_thread::sleep_for(std::chrono::seconds(1));
-  auto b = Rdtscp();
-  freq = (b - a) / 1'000'000;
-  return freq;
-}
 
 std::vector<uint128> GenerateTrace() {
   constexpr size_t kTraceLength = 2'000'000;

--- a/src/separated/primary_lat.cc
+++ b/src/separated/primary_lat.cc
@@ -1,0 +1,10 @@
+#include "combined/herd_main.h"
+
+int main(int argc, char **argv) {
+  FLAGS_colorlogtostderr = true;
+  FLAGS_alsologtostderr = true;
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
+  return 0;
+}

--- a/src/separated/primary_lat.cc
+++ b/src/separated/primary_lat.cc
@@ -20,10 +20,15 @@ unsigned long Rdtscp() {
 
 // Returns cycles per microseconds
 unsigned long MeasureClockFreq() {
+  static unsigned long freq = 0;
+  if (freq > 0) {
+    return freq;
+  }
   auto a = Rdtscp();
   std::this_thread::sleep_for(std::chrono::seconds(1));
   auto b = Rdtscp();
-  return (b - a) / 1'000'000;
+  freq = (b - a) / 1'000'000;
+  return freq;
 }
 
 std::vector<uint128> GenerateTrace() {

--- a/src/separated/primary_lat.cc
+++ b/src/separated/primary_lat.cc
@@ -1,11 +1,115 @@
 #include <folly/logging/xlog.h>
 #include <gflags/gflags.h>
+#include <x86intrin.h>
+
+#include <chrono>
+#include <thread>
+#include <vector>
 
 #include "herd_client.h"
+#include "util/zipfian_generator.h"
 
 DEFINE_int32(server_ports, 1, "Number of server IB ports");
 DEFINE_int32(client_ports, 1, "Number of client IB ports");
 DEFINE_int32(base_port_index, 0, "Base IB port index");
+
+unsigned long Rdtscp() {
+  unsigned int foo;
+  return __rdtscp(&foo);
+}
+
+// Returns cycles per microseconds
+unsigned long MeasureClockFreq() {
+  auto a = Rdtscp();
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  auto b = Rdtscp();
+  return (b - a) / 1'000'000;
+}
+
+std::vector<uint128> GenerateTrace() {
+  constexpr size_t kTraceLength = 2'000'000;
+  ZipfianGenerator gen(8 << 20, 0.99);
+  std::vector<uint128> trace;
+
+  for (size_t i = 0; i < kTraceLength; i++) {
+    int plain_key = gen.GetNumber();
+    trace.emplace_back(ConvertPlainKeyToHerdKey(plain_key));
+  }
+  return trace;
+}
+
+void WarmUp(HerdClient& cli, const std::vector<uint128>& trace) {
+  constexpr unsigned int kWarmUpIters = 1'000'000;
+
+  std::vector<HerdResp> resps;
+  for (unsigned int i = 0; i < kWarmUpIters; i++) {
+    auto key = trace[i % trace.size()];
+    while (!cli.PostRequest(key, nullptr, 0, false, key.second % NUM_WORKERS)) {
+      cli.GetResponses(resps);
+    }
+  }
+}
+
+// Computes median, 99% percentile and max
+std::tuple<double, double, double> CalculateStatistics(
+    std::vector<double>& latencies) {
+  std::sort(latencies.begin(), latencies.end());
+  auto count = latencies.size();
+  return std::make_tuple(latencies[count / 2], latencies[count * 99 / 100],
+                         latencies.back());
+}
+
+void BenchmarkOneOperation(HerdClient& cli, const std::vector<uint128>& trace,
+                           bool update) {
+  constexpr unsigned int kBenchmarkIter = 4'000'000;
+  auto cycle_per_us = MeasureClockFreq();
+  XLOGF(INFO, "Cycles per micro-second: {}.", cycle_per_us);
+
+  unsigned int idx = 0;
+  std::vector<HerdResp> resps;
+  std::vector<double> latencies;
+
+  for (unsigned int i = 0; i < kBenchmarkIter; i++) {
+    auto start = Rdtscp();
+    auto& key = trace[idx];
+    cli.PostRequest(key, nullptr, HERD_VALUE_SIZE, update,
+                    key.second % NUM_WORKERS);
+    cli.GetResponses(resps);
+    auto end = Rdtscp();
+
+    double us = static_cast<double>(end - start) / cycle_per_us;
+    latencies.push_back(us);
+    HRD_MOD_ADD(idx, trace.size());
+  }
+
+  // Measure average latency separately
+  idx = 0;
+  auto start = Rdtscp();
+  for (unsigned int i = 0; i < kBenchmarkIter; i++) {
+    auto& key = trace[idx];
+    cli.PostRequest(key, nullptr, HERD_VALUE_SIZE, update,
+                    key.second % NUM_WORKERS);
+    cli.GetResponses(resps);
+    HRD_MOD_ADD(idx, trace.size());
+  }
+  auto end = Rdtscp();
+  double avg = static_cast<double>(end - start) / cycle_per_us / kBenchmarkIter;
+
+  auto [median, tail, max] = CalculateStatistics(latencies);
+  XLOGF(INFO,
+        "{} latency: avg={:.2f}, median={:.2f}, 99%={:.2f}, max={:.2f} (us).",
+        update ? "update" : "read", avg, median, tail, max);
+}
+
+void BenchmarkMain(HerdClient& cli) {
+  auto trace = GenerateTrace();
+
+  WarmUp(cli, trace);
+  XLOG(INFO, "warm-up completed.");
+
+  BenchmarkOneOperation(cli, trace, true);
+  BenchmarkOneOperation(cli, trace, false);
+}
 
 int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
@@ -25,6 +129,8 @@ int main(int argc, char** argv) {
   HerdClient cli(0, FLAGS_server_ports, FLAGS_client_ports,
                  FLAGS_base_port_index);
   cli.ConnectToServer();
+
+  BenchmarkMain(cli);
 
   return 0;
 }

--- a/src/separated/timing.h
+++ b/src/separated/timing.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <x86intrin.h>
+
+#include <chrono>
+#include <thread>
+
+inline unsigned long Rdtscp() {
+  unsigned int foo;
+  return __rdtscp(&foo);
+}
+
+// Returns cycles per microseconds
+inline unsigned long MeasureClockFreq() {
+  static unsigned long freq = 0;
+  if (freq > 0) {
+    return freq;
+  }
+  auto a = Rdtscp();
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  auto b = Rdtscp();
+  freq = (b - a) / 1'000'000;
+  return freq;
+}

--- a/src/separated/tput_client.cc
+++ b/src/separated/tput_client.cc
@@ -1,9 +1,11 @@
+#include <folly/concurrency/ConcurrentHashMap.h>
 #include <folly/container/F14Set.h>
 #include <folly/logging/xlog.h>
 #include <gflags/gflags.h>
 
 #include <atomic>
 #include <boost/thread/barrier.hpp>
+#include <cmath>
 #include <future>
 #include <mutex>
 
@@ -16,7 +18,6 @@ constexpr int kHerdClientPorts = 1;  // Number of client IB ports
 constexpr int kHerdBasePortIdx = 0;  // Base IB port index
 
 constexpr int kCloverCoros = 4;
-constexpr unsigned int kOffloadSyncPeriod = 500'000;
 
 constexpr unsigned int kTraceLength = 10'000'000;
 constexpr double kZipfianAlpha = 0.99;
@@ -27,6 +28,8 @@ DEFINE_uint32(herd_mach_id, 0, "HERD machine id");
 DEFINE_uint32(clover_threads, 16, "Number of Clover client threads");
 DEFINE_uint32(update_pct, 5, "Percentage of update operation");
 DEFINE_uint32(bench_secs, 40, "Seconds to run benchmark");
+
+folly::ConcurrentHashMap<mitsume_key, bool> offloaded;
 
 static std::vector<uint128> GenerateTrace(int seed) {
   ZipfianGenerator gen(HERD_NUM_KEYS, kZipfianAlpha, seed);
@@ -46,6 +49,11 @@ void HerdWarmUp(HerdClient& cli, const std::vector<uint128>& trace) {
     auto key = trace[trace_idx];
     while (!cli.PostRequest(key, nullptr, HERD_VALUE_SIZE, false)) {
       cli.GetResponses(resps);
+      for (const auto& resp : resps) {
+        if (resp.Offloaded()) {
+          offloaded.insert(std::make_pair(resp.CloverKey(), true));
+        }
+      }
     }
 
     HRD_MOD_ADD(trace_idx, trace.size());
@@ -76,6 +84,11 @@ void HerdMain(const int global_id, boost::barrier& barrier,
     bool update = (hrd_fastrand(&hrd_rand_seed) % 100U) < FLAGS_update_pct;
     while (!cli.PostRequest(key, nullptr, HERD_VALUE_SIZE, update)) {
       cli.GetResponses(resps);
+      for (const auto& resp : resps) {
+        if (resp.Offloaded()) {
+          offloaded.insert(std::make_pair(resp.CloverKey(), true));
+        }
+      }
     }
 
     HRD_MOD_ADD(trace_idx, trace.size());
@@ -87,6 +100,83 @@ void HerdMain(const int global_id, boost::barrier& barrier,
   tput_prm.set_value(tput);
 }
 
+void CloverWorkCoro(coro_yield_t& yield, CloverCnThreadWrapper& cli,
+                    const std::vector<mitsume_key>& trace,
+                    unsigned int& trace_idx, int cid,
+                    unsigned long& completed) {
+  constexpr unsigned int kDummyBufSize = 4096;
+  thread_local static char kCloverInvalidValue[] = "_clover_err";
+
+  char dummy_buf[kDummyBufSize];
+  unsigned int dummy_len;
+
+  while (true) {
+    mitsume_key key = trace[trace_idx];
+    if (offloaded.find(key) != offloaded.end()) {
+      int rc =
+          cli.ReadKVPair(key, dummy_buf, &dummy_len, kDummyBufSize, cid, yield);
+      completed++;
+      if (rc == MITSUME_SUCCESS &&
+          strncmp(dummy_buf, kCloverInvalidValue, kDummyBufSize) == 0) {
+        rc = MITSUME_ERROR;
+      }
+      if (rc == MITSUME_ERROR) {
+        offloaded.erase(key);
+      }
+    }
+
+    HRD_MOD_ADD(trace_idx, trace.size());
+  }
+}
+
+void CloverMainCoro(coro_yield_t& yield, CloverCnThreadWrapper& cli,
+                    std::atomic_bool& stop_flag) {
+  while (!stop_flag.load(std::memory_order_acquire)) {
+    cli.YieldToAnotherCoro(kMasterCoroutineIdx, yield);
+  }
+}
+
+void CloverMain(CloverComputeNodeWrapper& node, int tid,
+                boost::barrier& barrier, std::atomic_bool& stop_flag,
+                std::promise<unsigned long> tput_prm) {
+  using clock = std::chrono::steady_clock;
+  using std::placeholders::_1;
+  CloverCnThreadWrapper cli(node, tid);
+
+  auto herd_trace = GenerateTrace(tid);
+  std::vector<mitsume_key> trace;
+  for (auto herd_key : herd_trace) {
+    trace.push_back(ConvertHerdKeyToCloverKey(
+        herd_key, HerdClient::PickRemoteWorker(herd_key)));
+  }
+
+  unsigned int trace_idx = 0;
+  unsigned long completed = 0;
+
+  cli.RegisterCoroutine(coro_call_t(std::bind(CloverMainCoro, _1, std::ref(cli),
+                                              std::ref(stop_flag))),
+                        kMasterCoroutineIdx);
+  for (int i = 1; i <= kCloverCoros; i++) {
+    cli.RegisterCoroutine(
+        coro_call_t(std::bind(CloverWorkCoro, _1, std::ref(cli),
+                              std::cref(trace), std::ref(trace_idx), i,
+                              std::ref(completed))),
+        i);
+  }
+
+  XLOGF(INFO, "Clover consumer {:2d} is ready.", tid);
+  barrier.wait();
+
+  auto start = clock::now();
+  cli.ExecuteMasterCoroutine();
+  auto end = clock::now();
+
+  double sec = std::chrono::duration<double>(end - start).count();
+  unsigned long tput = std::lround(completed / sec);
+  XLOGF(INFO, "Clover: {:8d} op/s", tput);
+  tput_prm.set_value(tput);
+}
+
 void CountDownMain(boost::barrier& barrier, std::atomic_bool& stop_flag) {
   barrier.wait();
   XLOGF(INFO, "Start benchmarking for {} seconds.", FLAGS_bench_secs);
@@ -95,10 +185,18 @@ void CountDownMain(boost::barrier& barrier, std::atomic_bool& stop_flag) {
 }
 
 int main(int argc, char** argv) {
+  {
+    auto reg_ip_env = std::getenv("HRD_REGISTRY_IP");
+    if (reg_ip_env != nullptr) {
+      XLOGF(INFO, "HERD registry: {}", reg_ip_env);
+      FLAGS_clover_memcached_ip = reg_ip_env;
+    }
+  }
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
 
+  XLOGF(INFO, "Clover memcached: {}", FLAGS_clover_memcached_ip);
   XLOGF(INFO, "Using {} HERD threads and {} Clover consumer threads.",
         FLAGS_herd_threads, FLAGS_clover_threads);
   XLOGF(INFO, "Fraction of update operations: {}%", FLAGS_update_pct);
@@ -106,16 +204,16 @@ int main(int argc, char** argv) {
   XLOG_IF(WARN, MITSUME_CLT_CONSUMER_GC_THREAD_NUMS > 0,
           "Using Clover GC threads at client-side is unnecessary.");
 
-  // CloverComputeNodeWrapper clvr_cli(FLAGS_clover_threads);
-  // clvr_cli.Initialize();
-  // XLOG(INFO, "Sleep 3 secs to wait Clover metadata server completes setup.");
-  // std::this_thread::sleep_for(std::chrono::seconds(3));
+  CloverComputeNodeWrapper clvr_node(FLAGS_clover_threads);
+  clvr_node.Initialize();
+  XLOG(INFO, "Sleep 3 secs to wait Clover metadata server completes setup.");
+  std::this_thread::sleep_for(std::chrono::seconds(3));
 
-  boost::barrier barrier(FLAGS_herd_threads + 1);
+  boost::barrier barrier(FLAGS_herd_threads + FLAGS_clover_threads + 1);
   std::atomic_bool stop_flag = ATOMIC_VAR_INIT(false);
 
   std::vector<std::thread> threads;
-  std::vector<std::future<unsigned long>> herd_tput_futs;
+  std::vector<std::future<unsigned long>> herd_tput_futs, clvr_tput_futs;
 
   for (unsigned int i = 0; i < FLAGS_herd_threads; i++) {
     std::promise<unsigned long> prm;
@@ -124,13 +222,22 @@ int main(int argc, char** argv) {
                          std::ref(barrier), std::ref(stop_flag),
                          std::move(prm));
   }
+  for (unsigned int i = 0; i < FLAGS_clover_threads; i++) {
+    std::promise<unsigned long> prm;
+    clvr_tput_futs.push_back(prm.get_future());
+    threads.emplace_back(CloverMain, std::ref(clvr_node), i, std::ref(barrier),
+                         std::ref(stop_flag), std::move(prm));
+  }
   threads.emplace_back(CountDownMain, std::ref(barrier), std::ref(stop_flag));
 
-  unsigned long herd_tput = 0;
+  unsigned long herd_tput = 0, clvr_tput = 0;
   for (auto& fut : herd_tput_futs) {
     herd_tput += fut.get();
   }
-  XLOGF(INFO, "HERD throughput: {} op/s.", herd_tput);
+  for (auto& fut : clvr_tput_futs) {
+    clvr_tput += fut.get();
+  }
+  XLOGF(INFO, "HERD: {} op/s, Clover: {} op/s", herd_tput, clvr_tput);
   for (auto& t : threads) {
     t.join();
   }

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -2,3 +2,6 @@ add_library(zipfian zipfian_generator.h zipfian_generator.cc)
 
 add_library(lru_records INTERFACE)
 target_link_libraries(lru_records INTERFACE Folly::folly)
+
+add_library(affinity affinity.h affinity.cc)
+target_link_libraries(affinity PUBLIC Threads::Threads PRIVATE Folly::folly)

--- a/src/util/affinity.cc
+++ b/src/util/affinity.cc
@@ -1,0 +1,14 @@
+#include "affinity.h"
+
+#include <folly/logging/xlog.h>
+
+void SetAffinity(std::thread& t, unsigned int core) {
+  cpu_set_t cpuset;
+  CPU_ZERO(&cpuset);
+  CPU_SET(core, &cpuset);
+  auto rc =
+      pthread_setaffinity_np(t.native_handle(), sizeof(cpu_set_t), &cpuset);
+  if (rc != 0) {
+    XLOGF(ERR, "Failed to set affinity to core {}!", core);
+  }
+}

--- a/src/util/affinity.h
+++ b/src/util/affinity.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <thread>
+#include <pthread.h>
+
+void SetAffinity(std::thread& t, unsigned int core);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(util)
 add_subdirectory(combined)
+add_subdirectory(separated)

--- a/tests/separated/CMakeLists.txt
+++ b/tests/separated/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(separated_herd_client_tests
+  herd_client_test_main.cc
+  herd_client_test.cc
+)
+
+target_link_libraries(separated_herd_client_tests
+  Catch2::Catch2
+  separated_herd_client
+)

--- a/tests/separated/herd_client_test.cc
+++ b/tests/separated/herd_client_test.cc
@@ -1,0 +1,62 @@
+#include "separated/herd_client.h"
+
+#include <catch2/catch.hpp>
+#include <map>
+#include <memory>
+
+constexpr int kGlobalClientId = 0;
+constexpr int kNumServerPorts = 1;
+constexpr int kNumClientPorts = 1;
+constexpr int kBaseIbPortIndex = 0;
+
+std::unique_ptr<HerdClient> SetupHerdClient() {
+  INFO("Expecting " << NUM_WORKERS << " worker threads at server.");
+  if (NUM_CLIENTS > 1) {
+    WARN("Using more than one client threads");
+  }
+  auto cli = std::make_unique<HerdClient>(kGlobalClientId, kNumServerPorts,
+                                          kNumClientPorts, kBaseIbPortIndex);
+  cli->ConnectToServer();
+  return cli;
+}
+
+TEST_CASE("Random read/write", "[herd_cli]") {
+  auto cli = SetupHerdClient();
+  std::vector<HerdResp> resps;
+  std::map<uint64_t, std::string> local_map;
+  constexpr int kTestIters = 1000;
+
+  for (int i = 1; i <= kTestIters; i++) {
+    auto mica_k = ConvertPlainKeyToHerdKey(i);
+    auto val = fmt::format("value_{:04d}", i);
+    while (!cli->PostRequest(ConvertPlainKeyToHerdKey(i), val.c_str(),
+                             HERD_VALUE_SIZE, true, i % NUM_WORKERS)) {
+      cli->GetResponses(resps);
+    }
+    local_map[mica_k.second] = val;
+  }
+  cli->GetResponses(resps);
+
+  auto check_resp = [&](const HerdResp& resp) {
+    std::string received;
+    for (auto p = resp.ValuePtr(); *p != '\0'; p++) {
+      received.push_back(*p);
+    }
+    const auto& expected = local_map[resp.Key().second];
+    REQUIRE(received == expected);
+  };
+
+  for (int i = 1; i <= kTestIters; i++) {
+    while (!cli->PostRequest(ConvertPlainKeyToHerdKey(i), nullptr, 0, false,
+                             i % NUM_WORKERS)) {
+      cli->GetResponses(resps);
+      for (auto& resp : resps) {
+        check_resp(resp);
+      }
+    }
+  }
+  cli->GetResponses(resps);
+  for (auto& resp : resps) {
+    check_resp(resp);
+  }
+}

--- a/tests/separated/herd_client_test_main.cc
+++ b/tests/separated/herd_client_test_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/tests/util/CMakeLists.txt
+++ b/tests/util/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(util_tests
   util_test_main.cc
   lru_records_test.cc
+  affinity_test.cc
 )
-target_link_libraries(util_tests Catch2::Catch2 lru_records)
+target_link_libraries(util_tests Catch2::Catch2 lru_records affinity Boost::thread)
 catch_discover_tests(util_tests)

--- a/tests/util/affinity_test.cc
+++ b/tests/util/affinity_test.cc
@@ -1,0 +1,24 @@
+#include "util/affinity.h"
+
+#include <boost/thread/barrier.hpp>
+#include <catch2/catch.hpp>
+#include <future>
+
+static void ThreadMain(boost::barrier& barrier, std::promise<int> core_prm) {
+  barrier.wait();
+  core_prm.set_value(sched_getcpu());
+}
+
+TEST_CASE("CPU affinity") {
+  constexpr int kCpuId = 2;
+  boost::barrier barrier(2);
+  std::promise<int> core_prm;
+  auto core = core_prm.get_future();
+
+  std::thread t(ThreadMain, std::ref(barrier), std::move(core_prm));
+  SetAffinity(t, kCpuId);
+  barrier.wait();
+  t.join();
+
+  REQUIRE(core.get() == kCpuId);
+}


### PR DESCRIPTION
Adds the following items:

- Implements a new HERD client wrapper.
- Implements a latency client for measuring primary KVS's latency.
- Implements a separated client with no direct communication between HERD and Clover client for lower overhead and decouple the performance numbers between the two clients.